### PR TITLE
Fix "undefined reference to `__atomic_load_8'"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OPTIMIZE=-O3
 #OPTIMIZE=-O0 -g
 
 COMPILEFLAGS=$(CFLAGS) $(OPTIMIZE) -DVERSION=\"$(VERSION)\" -Wall -Wextra -Wno-unused
-LINKFLAGS=$(LDFLAGS) -ljack -lsndfile -lm -lpthread -atomic
+LINKFLAGS=$(LDFLAGS) -ljack -lsndfile -lm -lpthread -latomic
 
 OS := $(shell uname)
 ifneq ($(OS),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OPTIMIZE=-O3
 #OPTIMIZE=-O0 -g
 
 COMPILEFLAGS=$(CFLAGS) $(OPTIMIZE) -DVERSION=\"$(VERSION)\" -Wall -Wextra -Wno-unused
-LINKFLAGS=$(LDFLAGS) -ljack -lsndfile -lm -lpthread
+LINKFLAGS=$(LDFLAGS) -ljack -lsndfile -lm -lpthread -atomic
 
 OS := $(shell uname)
 ifneq ($(OS),Darwin)


### PR DESCRIPTION
This PR adds `-latomic`:
```
LINKFLAGS=$(LDFLAGS) -ljack -lsndfile -lm -lpthread -latomic
```


This fixes the error I was getting the below with a `make` on Raspbian based Patchbox OS PiSound.
```
patch@patchbox:~/jack_capture $ sudo make

Checking dependencies: 
which bash
/usr/bin/bash
which tr
/usr/bin/tr
which sed
/usr/bin/sed
which install
/usr/bin/install
which pkg-config
/usr/bin/pkg-config
which gcc
/usr/bin/gcc
which g++
/usr/bin/g++
gcc -I/opt/local/include -E testsndfile.c >/dev/null
All seems good 

bash gen_setformat_c.sh >setformat.c
bash gen_das_config_h.sh >das_config.h

jack_capture was configured with the following options:
------------------------------
#define HAVE_OGG 1
#define HAVE_LAME 0
#define HAVE_LIBLO 1
//COMPILEFLAGS  -llo -lpthread
#define NEW_JACK_LATENCY_API 1
------------------------------

cat das_config.h |grep COMPILEFLAGS|sed s/\\/\\/COMPILEFLAGS//|tr '\n' ' ' >config_flags
gcc -I/opt/local/include -O3 -DVERSION=\"0.9.73\" -Wall -Wextra -Wno-unused jack_capture.c vringbuffer.c upwaker.c osc.c -o jack_capture  -ljack -lsndfile -lm -lpthread -lrt `cat config_flags`
jack_capture.c: In function ‘init_arguments’:
jack_capture.c:2468:31: warning: ‘.’ directive output of 1 bytes causes result to exceed ‘INT_MAX’ [-Wformat-overflow=]
  sprintf(base_filename,"%s%0*d.%s",filename_prefix,leading_zeros+1,++try,soundfile_format);
                               ^
/usr/bin/ld: /tmp/ccqeJLVk.o: in function `print_console':
jack_capture.c:(.text+0x1a0): undefined reference to `__atomic_load_8'
/usr/bin/ld: /tmp/ccqeJLVk.o: in function `process':
jack_capture.c:(.text+0x142c): undefined reference to `__atomic_load_8'
/usr/bin/ld: jack_capture.c:(.text+0x1464): undefined reference to `__atomic_fetch_add_8'
/usr/bin/ld: jack_capture.c:(.text+0x1470): undefined reference to `__atomic_load_8'
/usr/bin/ld: jack_capture.c:(.text+0x1500): undefined reference to `__atomic_fetch_add_8'
/usr/bin/ld: jack_capture.c:(.text+0x1584): undefined reference to `__atomic_load_8'
collect2: error: ld returned 1 exit status
make: *** [Makefile:63: jack_capture] Error 1
(reverse-i-search)`libs': sudo apt install libsndfile1-dev
```