### PR TITLE
Fix handling of command line arguments

### DIFF
--- a/jack_capture_gui
+++ b/jack_capture_gui
@@ -16,8 +16,6 @@
 #    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 
-OPTIONS=$@
-
 if [ ! `which zenity` ] ; then
     echo "zenity needed";
     exit;
@@ -27,7 +25,7 @@ while true
 do
   zenity  --question --ok-label="Yes" --cancel-label="No" --text="PRESS YES TO START REC"
   case "$?" in
-    0) `dirname $0`/jack_capture --no-stdin $OPTIONS &
+    0) `dirname $0`/jack_capture --no-stdin "$@" &
        some_pid=$!
        zenity --info --text=" RECORDING IN PROGRESS\n PRESS OK TO STOP REC "
        kill -s SIGINT $some_pid


### PR DESCRIPTION
Command line arguments for jack_capture were handled incorrectly,
preventing jack_capture to record when given jack port names that
include space characters.