### PR TITLE
Fix asprintf declaration

### DIFF
--- a/jack_capture.c
+++ b/jack_capture.c
@@ -919,7 +919,7 @@ static void stop_helper_thread(void){
 #define vsnprintf _vsnprintf
 #endif
 #ifndef __APPLE__
-int asprintf(char **buffer, char *fmt, ...) {
+int asprintf(char **buffer, const char *fmt, ...) {
     /* Guess we need no more than 200 chars of space. */
     int size = 200;
     int nchars;


### PR DESCRIPTION
The declaration of `asprintf` seems to be causing compilation issues on musl systems ([see here](https://bugs.gentoo.org/713388)). I'm also running into this issue while trying to package this for Alpine Linux. I believe this is because `char *fmt` isn't being declared as `const` in the function declaration, and I think it should be ([see asprintf man page](https://man7.org/linux/man-pages/man3/asprintf.3.html)). This seems to fix the `error: conflicting types for asprintf` error that gets thrown while trying to compile on a musl system.